### PR TITLE
文件上传健壮性

### DIFF
--- a/src/Components/FileTrait.php
+++ b/src/Components/FileTrait.php
@@ -15,6 +15,10 @@ trait FileTrait
 
     private $mimeType;
 
+    private $fileMd5;
+
+    private $mergerChunk;
+
     public function getUserId()
     {
         return $this->userId;
@@ -44,5 +48,26 @@ trait FileTrait
     {
         $this->mimeType=$mimeType;
     }
+
+    public function getFileMd5()
+    {
+        return $this->fileMd5;
+    }
+
+    public function setFileMd5($fileMd5)
+    {
+        $this->fileMd5=$fileMd5;
+    }
+
+    public function getMergerChunk()
+    {
+        return $this->mergerChunk;
+    }
+
+    public function setMergerChunk($mergerChunk)
+    {
+        $this->mergerChunk=$mergerChunk;
+    }
+
 
 }

--- a/src/Components/ResourceFile.php
+++ b/src/Components/ResourceFile.php
@@ -2,7 +2,6 @@
 /**
  * @author lishen chen frankchenls@outlook.com
  */
-
 namespace App\Components;
 
 /**
@@ -23,8 +22,4 @@ class ResourceFile extends UploadFile
     {
         $this->courseId=$courseId;
     }
-
-
-
-
 }

--- a/src/Components/UploadFile.php
+++ b/src/Components/UploadFile.php
@@ -2,113 +2,72 @@
 /**
  * @author lishen chen frankchenls@outlook.com
  */
-
 namespace App\Components;
 
-
-class UploadFile
+/**
+ *  Common features needed in a file.
+ */
+trait FileTrait
 {
-    use FileTrait;
-    /**
-     * @var string
-     * The absolute path of a file.
-     * eg. /home/demoFile.txt
-     */
-    private $filePath;
+    private $userId;
 
-    /**
-     * @var string
-     */
-    private $fileName;
-    /**
-     * @var array
-     * The absolute path array of all chunks .
-     * eg. ['/home/demoFile.txt_chunk_1','/home/demoFile.txt_chunk_2',...]
-     */
-    private $fileChunks=array();
-    /**
-     * @var array
-     * The digests of all chunks.
-     * These digests can be calculate via many digest algorithm,like MD5,SHA256,etc.
-     */
-    private $chunksDigest=array();
-    /**
-     * @var bool
-     * Become true when file chunks satisfy merge condition.
-     */
-    private $isCanBeMerged;
+    private $fileSize;
 
-    /**
-     * @var bool
-     * Become true when all of the file chunks are successfully merged.
-     */
-    private $isMergeCompleted;
+    private $mimeType;
 
-    private $isUploadFinished;
+    private $fileMd5;
 
+    private $mergerChunk;
 
-    public function __construct($filePath)
+    public function getUserId()
     {
-        $this->filePath=$filePath;
-        $this->isCanBeMerged=false;
-        $this->isMergeCompleted=false;
-        $this->isUploadFinished=false;
-        $this->fileName=substr($filePath,strrpos($filePath,"/")+1);
-        $this->fileChunks=\array_diff(scandir(substr($filePath,0,strrpos($filePath,"/"))),['.','..']);
+        return $this->userId;
     }
 
-    public function getFileName()
+    public function setUserId($userId)
     {
-        return $this->fileName;
+        $this->userId=$userId;
     }
 
-    public function getChunks()
+    public function getFileSize()
     {
-        return $this->fileChunks;
+        return $this->fileSize;
     }
 
-    public function getChunksDigest()
+    public function setFileSize($fileSize)
     {
-        return $this->chunksDigest;
+        $this->fileSize=$fileSize;
     }
 
-    public function setChunksDigest($chunkPath,$digest)
+    public function getMimeType()
     {
-        $this->chunksDigest[$chunkPath]=$digest;
+        return $this->mimeType;
     }
 
-    public function getFilePath()
+    public function setMimeType($mimeType)
     {
-        return $this->filePath;
-    }
-    public function setIsCanBeMergeStatus($status)
-    {
-        $this->isCanBeMerged=$status;
+        $this->mimeType=$mimeType;
     }
 
-    public function setIsMergeCompleted($status)
+    public function getFileMd5()
     {
-        $this->isMergeCompleted=$status;
+        return $this->fileMd5;
     }
 
-    public function isCanBeMerged()
+    public function setFileMd5($fileMd5)
     {
-        return $this->isCanBeMerged;
+        $this->fileMd5=$fileMd5;
     }
 
-    public function isMergeCompleted()
+    public function getMergerChunk()
     {
-        return $this->isMergeCompleted;
+        return $this->mergerChunk;
     }
 
-    public function setIsUploadFinished($status)
+    public function setMergerChunk($mergerChunk)
     {
-        $this->isUploadFinished=$status;
+        $this->mergerChunk=$mergerChunk;
     }
 
-    public function isUploadFinished()
-    {
-        return $this->isUploadFinished;
-    }
 
 }

--- a/src/Event/FileChunkArrivedEvent.php
+++ b/src/Event/FileChunkArrivedEvent.php
@@ -5,6 +5,7 @@
 namespace App\Event;
 use App\Components\UploadFile;
 
+
 class FileChunkArrivedEvent extends FileEvent
 {
     private $chunkPath;
@@ -17,7 +18,6 @@ class FileChunkArrivedEvent extends FileEvent
     }
 
     public function getChunkPath(){
-
         return $this->chunkPath;
     }
 

--- a/src/Event/FileEvent.php
+++ b/src/Event/FileEvent.php
@@ -44,8 +44,4 @@ class FileEvent extends Event
         return $this->file->getChunks();
     }
 
-
-
-
-
 }

--- a/src/Event/FileMergeEvent.php
+++ b/src/Event/FileMergeEvent.php
@@ -5,17 +5,18 @@
 
 namespace App\Event;
 
-
 use App\Components\UploadFile;
 
 class FileMergeEvent extends FileEvent
 {
+    private $chunkPath;
     private $mergeChunksIndex=array();
 
-    public function __construct(UploadFile $file,array $mergeChunksIndex)
+    public function __construct(UploadFile $file,array $mergeChunksIndex,$chunkPath)
     {
         parent::__construct($file);
         $this->setMergeChunksIndex($mergeChunksIndex);
+        $this->chunkPath=$chunkPath;
     }
 
     public function setMergeChunksIndex(array $index){
@@ -26,5 +27,8 @@ class FileMergeEvent extends FileEvent
         return $this->mergeChunksIndex;
     }
 
+    public function getChunkPath(){
+        return $this->chunkPath;
+    }
 
 }

--- a/src/EventListener/FileUploadListener.php
+++ b/src/EventListener/FileUploadListener.php
@@ -9,9 +9,19 @@ use App\FileUploadEvents;
 use App\Event\FileChunkArrivedEvent;
 use App\Event\FileMergeEvent;
 use App\Event\FileMergeCompletedEvent;
+use App\Service\RedisService;
+use BFS\FileSystem;
+
+
 
 class FileUploadListener implements EventSubscriberInterface
 {
+    private $redis;
+
+    public function __construct(RedisService $redis)
+    {
+        $this->redis=$redis;
+    }
     /**
      * Called when a file chunk arrived.
      */
@@ -19,26 +29,75 @@ class FileUploadListener implements EventSubscriberInterface
         /**
          * check if the chunk can be merge in to a file.
          */
-        //do something....
+        if(!file_exists($event->getFile()->getFilePath()))
+            mkdir($event->getFile()->getFilePath(),0755,true);
         $event->getFile()->setIsCanBeMergeStatus(true);
-        $event->setMergeChunksIndex([1,2,3]);
 
-
+//        if($event->getFile()->getChunk()==0){
+//            $chunk_array=$event->getChunks();
+//            for ($i=0;$i<$event->getFile()->getChunks();$i++){
+//                $chunk_array[$i]=0;
+//            }
+//            $chunk_array[0]=1;
+//              $event->getFile()->setMergerChunk(0);
+//        }else{
+//            $chunk_array[$event->getFile()->getChunk()]=1;
+//        }
     }
-
+//    public function Search(FileMergeEvent $event)
+//    {
+//        $chunk_array=$event->getChunks();
+//        $chunk_index=$event->getMergeChunksIndex();
+//        for($i=$event->getFile()->getMergerChunk();$i<$event->getFile()->getChunks();$i++){
+//            if($chunk_array[$i]==1){
+//                array_push($chunk_index,$i);
+//            }else{
+//                $event->getFile()->setMergerChunk($i);
+//                break;
+//            }
+//        }
+//
+//    }
     /**
      * Called when some chunks of a file can be merge.
      */
     public function onMerge(FileMergeEvent $event){
+        //       Search($event);
 
         $event->getFile()->setIsCanBeMergeStatus(false);
 
-        $chunksIndex=$event->getMergeChunksIndex();
-        //do something....
+        $in=fopen($event->getChunkPath(),'r');
+
+        if($event->getFile()->getChunk()==0){
+            $out=fopen($event->getFile()->getFilePath().'0','w');
+        }else if($event->getFile()->getChunk()==-1){
+            $out=fopen($event->getFile()->getFilePath().$event->getFile()->getFileName(),'w');
+        }else if($event->getFile()->getChunk()==$event->getFile()->getChunks()-1){
+            $bfs_in=fopen($event->getFile()->getFilePath().($event->getFile()->getChunk()-1),'r');
+            $out=fopen($event->getFile()->getFilePath().$event->getFile()->getFileName(),'w');
+        }else {
+            $bfs_in=fopen($event->getFile()->getFilePath().($event->getFile()->getChunk()-1),'r');
+            $out=fopen($event->getFilePath().$event->getFile()->getChunk(),'w');
+        }
+
+        if ($event->getFile()->getChunk()>0){
+            while(!feof($bfs_in)){
+                fwrite($out,fread($bfs_in,4096));
+            }
+            while(!feof($in)){
+                fwrite($out,fread($in,4096));
+            }
+            fclose($bfs_in);
+            @unlink($event->getFile()->getFilePath().($event->getFile()->getChunk()-1));
+        }else{
+            while(!feof($in)){
+                fwrite($out,fread($in,4096));
+            }
+        }
+        fclose($in);
+        fclose($out);
 
         $event->getFile()->setIsMergeCompleted(true);
-
-
     }
     /**
      * Called when all of file chunks arrived and the file was completely merged.
@@ -49,18 +108,20 @@ class FileUploadListener implements EventSubscriberInterface
         /**
          * Check file integrity and persist the file into the database.
          */
-
-        // do something
-
-        //$event->getFile()->setIsUploadFinished(true);
-
+        $event->getFile()->setIsMergeCompleted(false);
+        if($event->getFile()->getChunk()>0)
+            $this->redis->getRedisClient()->sadd($event->getFile()->getUserId().$event->getFile()->getFileName(),$event->getFile()->getChunk());
+        else if($event->getFile()->getChunk()==0){
+            $this->redis->getRedisClient()->sadd($event->getFile()->getUserId().$event->getFile()->getFileName(),$event->getFile()->getChunk());
+            $this->redis->getRedisClient()->expire($event->getFile()->getUserId().$event->getFile()->getFileName(),6*60*60);
+        }
+        $event->getFile()->setIsUploadFinished(true);
     }
     public static function getSubscribedEvents(){
         return [
             FileUploadEvents::CHUNK_ARRIVED=>['onChunkArrived',32],
             FileUploadEvents::MERGE=>['onMerge',16],
             FileUploadEvents::MERGE_COMPLETED=>['onMergeCompleted'],
-
         ];
     }
 }

--- a/src/Service/Uploader.php
+++ b/src/Service/Uploader.php
@@ -4,30 +4,37 @@
  */
 
 namespace App\Service;
+use App\Components\ResourceFile;
 use App\Entity\File;
 use App\Event\FileMergeCompletedEvent;
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use App\Components\UploadFile;
 use App\Components\FileQueue;
 use App\Event\FileChunkArrivedEvent;
 use App\Event\FileMergeEvent;
 use App\FileUploadEvents;
+use BFS\Exception\IOExceptionInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use BFS\FileSystem;
+use App\Service\RedisService;
+
 
 class Uploader implements UploaderInterface
 {
     protected $dispatcher;
     protected $fileQueue;
     protected $entityManager;
-    protected $parameterBag;
+    protected $redis;
+    protected $params;
 
-    public function __construct(EventDispatcherInterface $dispatcher,EntityManagerInterface $entityManager,ParameterBagInterface $bag)
+    public function __construct(EventDispatcherInterface $dispatcher,EntityManagerInterface $entityManager,FileQueue $fileQueue=null,RedisService $redis,ParameterBagInterface $params)
     {
         $this->dispatcher=$dispatcher;
-        $this->fileQueue=new FileQueue();
+        $this->fileQueue=$fileQueue?:new FileQueue();
         $this->entityManager=$entityManager;
-        $this->parameterBag=$bag;
+        $this->redis=$redis;
+        $this->params=$params;
     }
 
     /**
@@ -41,26 +48,23 @@ class Uploader implements UploaderInterface
         if(!$this->fileQueue->hasFile($file->getFilePath()))
             $this->fileQueue->addFile($file->getFilePath(),$file);
 
-
         $this->dispatcher->dispatch(FileUploadEvents::CHUNK_ARRIVED,$event);
 
         if($event->getFile()->isCanBeMerged())
         {
-            $mergeEvent=new FileMergeEvent($event->getFile(),$event->getMergeChunksIndex());
+            $mergeEvent=new FileMergeEvent($event->getFile(),$event->getMergeChunksIndex(),$fileChunkPath);
             $this->dispatcher->dispatch(FileUploadEvents::MERGE,$mergeEvent);
-
         }
         if($event->getFile()->isMergeCompleted())
         {
             $mergeCompletedEvent=new FileMergeCompletedEvent($file);
             $this->dispatcher->dispatch(FileUploadEvents::MERGE_COMPLETED,$mergeCompletedEvent);
-            if($file->isUploadFinished())
+            if($file->isUploadFinished()) {
                 $this->finishUpload($file);
+                //     $this->recordFileMd5($file);
+            }
         }
-
         return $file->isUploadFinished()?'UploadFinished':'Uploading';
-
-
     }
 
     /**
@@ -80,18 +84,48 @@ class Uploader implements UploaderInterface
         return false;
     }
 
+    public function recordFileMd5(ResourceFile $uploaderFile)
+    {
+        if($uploaderFile->getChunk()!=-1&&$uploaderFile->getChunk()==$uploaderFile->getChunks()-1){
+            $md5Dir=$this->params->get('apady_directory').$uploaderFile->getUserId().'/';
+            if(!file_exists($md5Dir)){
+                mkdir($md5Dir,0755,true);
+            }
+            if(!file_exists($md5Dir.$uploaderFile->getFileMd5())){
+                $handle=@fopen($md5Dir.$uploaderFile->getFileMd5(),"w");
+                fwrite($handle,$uploaderFile->getFilePath());
+            }
+        }
+    }
     /**
      * Called when upload finished.
-     * @param UploadFile $uploadFile
+     * @param ResourceFile $file
+     * @return bool
      */
-    private function finishUpload(UploadFile $uploadFile)
+    public function finishUpload(ResourceFile $uploaderFile)
     {
-        $this->fileQueue->removeFile($uploadFile->getFilePath());
-//        $file=new File();
-//        $file->setFileName($uploadFile->getFileName());
-//        $file->setPath($uploadFile->getFilePath());
-//        $this->entityManager->persist($file);
-//        $this->entityManager->flush();
+        $this->fileQueue->removeFile($uploaderFile->getFilePath());
+        if($uploaderFile->getChunk()==$uploaderFile->getChunks()-1||$uploaderFile->getChunks()==null) {
+            $course = $this->entityManager->getRepository('App:Courses')
+                ->find($uploaderFile->getCourseId());
+            if ($course == NULL) {
+                return false;
+            }
+            $user = $this->entityManager->getRepository('App:User')
+                ->find($uploaderFile->getUserId());
+            $file = new File();
+            $file->setUser($user);
+            $file->setMimeType($uploaderFile->getMimeType());
+            $file->setSize($uploaderFile->getFileSize());
+            $file->setFileName($uploaderFile->getFileName());
+            $file->setPath('/'.$user->getUsername().$user->getId().'/'.$uploaderFile->getCourseId().'/教学资源/'.$uploaderFile->getFileName().'/');
+            $this->entityManager->persist($file);
+            $course->addResourceFile($file);
+            $this->entityManager->flush();
 
+            $this->redis->getRedisClient()->del($uploaderFile->getUserId().$uploaderFile->getFileName());
+            return true;
+        }
+        return true;
     }
 }

--- a/templates/course.html.twig
+++ b/templates/course.html.twig
@@ -112,13 +112,13 @@
                     <div id="file-category">
                         <div id="fileTags"></div>
                         {#<ul>#}
-                            {#<li onclick="acategory(this);return false;" style="background-color: #4bb9ea;">全部</li>#}
-                            {#<li onclick="acategory(this);return false;" style="background-color: #939c9c;">测试</li>#}
-                            {#{% for tag in tags %}#}
+                        {#<li onclick="acategory(this);return false;" style="background-color: #4bb9ea;">全部</li>#}
+                        {#<li onclick="acategory(this);return false;" style="background-color: #939c9c;">测试</li>#}
+                        {#{% for tag in tags %}#}
 
-                                {#<li onclick="acategory(this);return false;" style="background-color: #939c9c;">{{ tag.tag }}</li>#}
-                            {#{% endfor %}#}
-                            {#<li onclick="setcategory(this);return false;" style="background-color: #939c9c;"><img src="{{ asset('img/setcategory.svg') }}" style="height: 20px;"></li>#}
+                        {#<li onclick="acategory(this);return false;" style="background-color: #939c9c;">{{ tag.tag }}</li>#}
+                        {#{% endfor %}#}
+                        {#<li onclick="setcategory(this);return false;" style="background-color: #939c9c;"><img src="{{ asset('img/setcategory.svg') }}" style="height: 20px;"></li>#}
                         {#</ul>#}
                         <div id="file-upload" onclick="showModal();return false;">
                             <img src="{{ asset('img/plus.svg') }}" style="height: 21px;left: 3px;">
@@ -138,40 +138,40 @@
 
     {#上传功能#}
     {% if is_granted('ROLE_TEACHER') %}
-    <!--遮罩-->
-    <div class="overlay"></div>
-    <!--上传框-->
-    <div class="dropbox"  id="modal" style="z-index: -100;">
-        <div id="close" style="cursor:pointer;float: right;width:20px" onclick="closeModal();return false;">
-            <span class="css-close"></span>
-        </div>
-        <div id="wrapper" >
-            <div id="container">
-                <!--头部，相册选择和格式选择-->
+        <!--遮罩-->
+        <div class="overlay"></div>
+        <!--上传框-->
+        <div class="dropbox"  id="modal" style="z-index: -100;">
+            <div id="close" style="cursor:pointer;float: right;width:20px" onclick="closeModal();return false;">
+                <span class="css-close"></span>
+            </div>
+            <div id="wrapper" >
+                <div id="container">
+                    <!--头部，相册选择和格式选择-->
 
-                <div id="uploader" style="height: 270px;">
-                    <div class="queueList" style="height: 317px;overflow: auto;margin: 20px;">
-                        <div id="dndArea" class="placeholder" style="position: absolute;width: 600px;">
-                            <div id="filePicker"></div>
-                            <p>或将文件拖到这里，单次最多可选30个</p>
+                    <div id="uploader" style="height: 270px;">
+                        <div class="queueList" style="height: 317px;overflow: auto;margin: 20px;">
+                            <div id="dndArea" class="placeholder" style="position: absolute;width: 600px;">
+                                <div id="filePicker"></div>
+                                <p>或将文件拖到这里，单次最多可选30个</p>
+                            </div>
                         </div>
-                    </div>
-                    <div class="statusBar" style="display:none;">
-                        <div class="progress" >
-                            <span class="text">0%</span>
-                            <span class="percentage"></span>
-                        </div><div class="info"></div>
-                        <div class="btns">
-                            <div id="filePicker2"></div><div class="uploadBtn">开始上传</div>
+                        <div class="statusBar" style="display:none;">
+                            <div class="progress" >
+                                <span class="text">0%</span>
+                                <span class="percentage"></span>
+                            </div><div class="info"></div>
+                            <div class="btns">
+                                <div id="filePicker2"></div><div class="uploadBtn">开始上传</div>
+                            </div>
                         </div>
                     </div>
                 </div>
             </div>
         </div>
-    </div>
 
 
-{% endif %}
+    {% endif %}
 
 
 
@@ -180,13 +180,11 @@
 {% block page_js %}
     <script>
         //文件上传URL全局变量
-        window.file_upload_index_url ='{{ path('fileUploadIndex') }}'
-        window.file_upload_merge_url ='{{ path('fileUploadMerge') }}'
+        window.file_upload_index_url ='{{ path('fileUploadIndex',{'courseId':course.id}) }}'
         window.file_upload_check_url ='{{ path('fileUploadCheck',{'courseId':course.id}) }}'
-        window.file_md5_url ='{{ path('fileMd5') }}'
-        window.file_persist_url ='{{ path('fileUploadPersist',{'courseId':course.id}) }}'
+        window.file_get_chunks_url ='{{ path('fileGetChunks') }}'
 
-       //加入课程
+        //加入课程
 
         function joinCourse(){
 
@@ -200,7 +198,7 @@
                 success:function (data) {
                     if(data.status==200){
 
-                            $("#join_the_course").css("background-color", "rgba(16, 0, 8, 0.2)");
+                        $("#join_the_course").css("background-color", "rgba(16, 0, 8, 0.2)");
 
                         $("#join_status").html("已加入");
 
@@ -332,7 +330,7 @@
             }
 
             modalFrame("添加到","small",formSelect("setTagSelect","选择分类",getTags,nowtag,"tag")+
-            formButton("确定","setFileTagSubmit("+fileid+")"))
+                formButton("确定","setFileTagSubmit("+fileid+")"))
 
         }
         function setFileTagSubmit(fileid){
@@ -384,65 +382,65 @@
                 type:"get",
                 url:"{{ path('getResourceFiles',{'id':course.id}) }}",                      //请求URL,对应后台Controller中的路由
                 success:function(data){                    //后台返回响应结果时会自动执行该回调函数
-                var gh=0;//隔行换色标志
-                $("#fileTotal").text(data.length);
-                for(var p in data){
+                    var gh=0;//隔行换色标志
+                    $("#fileTotal").text(data.length);
+                    for(var p in data){
 
-                //文件图标
-                imgurl=data[p].type;
-                imgurl=getFileIcon(imgurl.toLowerCase());
-                //截取文件名
-                    data[p].file_name=splitFileName(data[p].file_name);
-                //过长文件名处理
-                    //
-                    var shortName=data[p].file_name;
-                    if(data[p].file_name.length>=10) {
-                        shortName=data[p].file_name.substring(0,10)+"…";
+                        //文件图标
+                        imgurl=data[p].type;
+                        imgurl=getFileIcon(imgurl.toLowerCase());
+                        //截取文件名
+                        data[p].file_name=splitFileName(data[p].file_name);
+                        //过长文件名处理
+                        //
+                        var shortName=data[p].file_name;
+                        if(data[p].file_name.length>=10) {
+                            shortName=data[p].file_name.substring(0,10)+"…";
+                        }
+                        //隔行变色
+                        gh++;
+                        var bgcolor=gh%2==1?"#fafbff":"white";
+                        $("#leftfield").prepend("<div class=\"totag-"+data[p].file_tag_id+" content-project\" startcolor=\""+bgcolor+"\" style=\"background-color: "+bgcolor+";\">\n" +
+                            "                            <img src=\"/img/fileicon/"+imgurl+".svg\">\n" +
+                            "                            <div class=\"content-text\">\n" +
+                            "                            <p title=\""+data[p].file_name+"\" class=\"content-text-name\"><a class=\"content-zuoye\">["+data[p].type+"]</a>"+shortName+"</p>\n" +
+                            "                            <p class=\"content-text-info\">大小:"+data[p].size+" <rq>/ 修改日期:"+data[p].updated_at+"</rq></p>\n" +
+                            "                            </div>\n" +
+                            "                            <button onclick=\"downloadFile("+data[p].id+")\" class=\"button-download\" target=\"view_window\" style=\"display: none;\">下载</button>\n" +
+                            "                            <button class=\"button-more\" style=\"display: none;\">···</button>\n" +
+                            "                            <div class=\"morelist\"><ul>\n" +
+                            "                                    <li>预览</li>\n" +
+                            "                                    <li onclick=\"selectShareWay("+data[p].id+");\">分享</li>\n" +
+                            "                                    <li onclick='renamefile(\""+data[p].file_name+"\","+data[p].id+",{{ course.id }});'>重命名</li>\n" +
+                            "                                    <li onclick=\"setFileTag("+data[p].id+","+data[p].file_tag_id+");\">添加到</li>\n" +
+                            "                                    <li onclick='removefile(\""+data[p].id+"\",{{ course.id }});'>删除</li>\n" +
+                            "                                </ul></div>\n" +
+                            "                        </div>");
+                        $("#leftfield").children().bind("mouseover",function () {
+
+                            $(this).css("background-color","#F2F9FF");
+                            $(this).find(".button-download").css("display","block");
+                            $(this).find(".button-more").css("display","block");
+                        });
+                        $(".button-more").bind("mouseover",function () {
+                            $(this).next().css("display","block");
+                        });
+                        $(".button-more").bind("mouseout",function () {
+                            $(this).next().css("display","none");
+                        });
+                        $(".morelist").bind("mouseout",function () {
+                            $(this).css("display","none");
+                        });
+                        $(".morelist").bind("mouseover",function () {
+                            $(this).css("display","block");
+                        });
+                        $("#leftfield").children().bind("mouseout",function () {
+
+                            $(this).css("background-color",$(this).attr("startcolor"));
+                            $(this).find(".button-download").css("display","none");
+                            $(this).find(".button-more").css("display","none");
+                        });
                     }
-                //隔行变色
-                    gh++;
-                    var bgcolor=gh%2==1?"#fafbff":"white";
-                    $("#leftfield").prepend("<div class=\"totag-"+data[p].file_tag_id+" content-project\" startcolor=\""+bgcolor+"\" style=\"background-color: "+bgcolor+";\">\n" +
-                        "                            <img src=\"/img/fileicon/"+imgurl+".svg\">\n" +
-                        "                            <div class=\"content-text\">\n" +
-                        "                            <p title=\""+data[p].file_name+"\" class=\"content-text-name\"><a class=\"content-zuoye\">["+data[p].type+"]</a>"+shortName+"</p>\n" +
-                        "                            <p class=\"content-text-info\">大小:"+data[p].size+" <rq>/ 修改日期:"+data[p].updated_at+"</rq></p>\n" +
-                        "                            </div>\n" +
-                        "                            <button onclick=\"downloadFile("+data[p].id+")\" class=\"button-download\" target=\"view_window\" style=\"display: none;\">下载</button>\n" +
-                        "                            <button class=\"button-more\" style=\"display: none;\">···</button>\n" +
-                        "                            <div class=\"morelist\"><ul>\n" +
-                        "                                    <li>预览</li>\n" +
-                        "                                    <li onclick=\"selectShareWay("+data[p].id+");\">分享</li>\n" +
-                        "                                    <li onclick='renamefile(\""+data[p].file_name+"\","+data[p].id+",{{ course.id }});'>重命名</li>\n" +
-                        "                                    <li onclick=\"setFileTag("+data[p].id+","+data[p].file_tag_id+");\">添加到</li>\n" +
-                        "                                    <li onclick='removefile(\""+data[p].id+"\",{{ course.id }});'>删除</li>\n" +
-                        "                                </ul></div>\n" +
-                        "                        </div>");
-                    $("#leftfield").children().bind("mouseover",function () {
-
-                        $(this).css("background-color","#F2F9FF");
-                        $(this).find(".button-download").css("display","block");
-                        $(this).find(".button-more").css("display","block");
-                    });
-                    $(".button-more").bind("mouseover",function () {
-                        $(this).next().css("display","block");
-                    });
-                    $(".button-more").bind("mouseout",function () {
-                        $(this).next().css("display","none");
-                    });
-                    $(".morelist").bind("mouseout",function () {
-                        $(this).css("display","none");
-                    });
-                    $(".morelist").bind("mouseover",function () {
-                        $(this).css("display","block");
-                    });
-                    $("#leftfield").children().bind("mouseout",function () {
-
-                        $(this).css("background-color",$(this).attr("startcolor"));
-                        $(this).find(".button-download").css("display","none");
-                        $(this).find(".button-more").css("display","none");
-                    });
-                }
 
                 },
                 error:function(data){
@@ -521,19 +519,19 @@
         function removefile(fid,cid){
             var r=confirm("确定删除该文件？");
             if(r==true){
-            $.ajax({                                 //AJAX
-                type:"get",
-                url:'{{ path('fileRemove',{'fileId':'fileId','courseId':'courseId'})}}'.replace('fileId',fid).replace('courseId',cid),                      //请求URL,对应后台Controller中的路由
-                success:function(data){
-                    filelist();
-                    messageOk("删除成功")
-                },
+                $.ajax({                                 //AJAX
+                    type:"get",
+                    url:'{{ path('fileRemove',{'fileId':'fileId','courseId':'courseId'})}}'.replace('fileId',fid).replace('courseId',cid),                      //请求URL,对应后台Controller中的路由
+                    success:function(data){
+                        filelist();
+                        messageOk("删除成功")
+                    },
 
-                error:function(data){
-                    alert("服务器添加失败");
-                },
-                dataType:"json"
-            })
+                    error:function(data){
+                        alert("服务器添加失败");
+                    },
+                    dataType:"json"
+                })
             }
         }
 


### PR DESCRIPTION
1.将fileController merger persist md5无用的action 去掉。
2.增加了get chunks action，主要用来从redis里面获取已经上传了的文件分片序号
3.简化了文件上传前check的功能，现在主要就是检查一下重名文件是否要加一问题。因为这个要查数据库，所以在文件进入上传队列之时就开始动作。
4.修改文件路径，将课程名字改为课程id
5.往uploader服务里增添文件merger已经写库功能。注意chunks为一共用多少文件分片,chunk为当前文件分片。若文件不用分片chunk为-1.
6.当前采用合并是直接在bfs里面合并。